### PR TITLE
Fix/checkstyle warnings

### DIFF
--- a/app/controllers/v1/ControllerUtils.scala
+++ b/app/controllers/v1/ControllerUtils.scala
@@ -5,7 +5,7 @@ import java.time.format.{ DateTimeFormatter, DateTimeParseException }
 import java.util.Optional
 import javax.naming.ServiceUnavailableException
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ Future, TimeoutException }
 import scala.util.{ Failure, Success, Try }
@@ -38,7 +38,7 @@ trait ControllerUtils extends Controller with StrictLogging {
 
   protected def validateYearMonth(key: String, raw: String) = {
     val yearAndMonth = Try(YearMonth.parse(raw, DateTimeFormatter.ofPattern("yyyyMM")))
-    yearAndMonth match {
+    (yearAndMonth: @unchecked) match {
       case Success(s) =>
         ReferencePeriod(key, s)
       case Failure(ex: DateTimeParseException) =>
@@ -67,10 +67,10 @@ trait ControllerUtils extends Controller with StrictLogging {
   protected def matchByEditParams(id: Option[String], request: Request[AnyContent], period: Option[String] = None): RequestEvaluation = {
     val key = id.getOrElse("")
     if (key.length >= minKeyLength) {
-      (period, request.body.asJson) match {
+      ((period, request.body.asJson): @unchecked) match {
         case (None, Some(body)) => validateEditEntJson(key, body)
         case (Some(period), Some(body)) => {
-          validateYearMonth(key, period) match {
+          (validateYearMonth(key, period): @unchecked) match {
             case v: ReferencePeriod => validateEditEntJson(key, body, Some(v.period))
             case i: InvalidReferencePeriod => i
           }
@@ -106,7 +106,7 @@ trait ControllerUtils extends Controller with StrictLogging {
   protected def resultMatcher[Z](v: Optional[Z], msg: Option[String] = None): Future[Result] = {
     Future { toOption[Z](v) }.map {
       case Some(x: java.util.List[StatisticalUnit]) =>
-        tryAsResponse(Try(Json.toJson(x.toList.map { v => UnitLinks(v) })))
+        tryAsResponse(Try(Json.toJson(x.asScala.toList.map { v => UnitLinks(v) })))
       case Some(x: Enterprise) =>
         tryAsResponse(Try(Json.toJson(EnterpriseUnit(x))))
       case Some(x: StatisticalUnitLinks) =>

--- a/app/controllers/v1/EditController.scala
+++ b/app/controllers/v1/EditController.scala
@@ -1,6 +1,6 @@
 package controllers.v1
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 import io.swagger.annotations._
@@ -35,9 +35,9 @@ class EditController extends ControllerUtils {
   ): Action[AnyContent] = Action.async { implicit request =>
     Logger.info(s"Editing by default period for id: ${id}")
     val evalResp = matchByEditParams(Some(id), request)
-    val res = evalResp match {
+    val res = (evalResp: @unchecked) match {
       case (x: EditRequest) => {
-        val resp = Try(requestEnterprise.updateEnterpriseVariableValues(x.id, x.updatedBy, x.edits)) match {
+        val resp = Try(requestEnterprise.updateEnterpriseVariableValues(x.id, x.updatedBy, x.edits.asJava)) match {
           case Success(s) => Ok(errAsJson(OK, "edit_success", s"Edit has been made successfully to Enterprise with id: ${x.id}")).future
           case Failure(ex) => InternalServerError(errAsJson(INTERNAL_SERVER_ERROR, "edit_error", s"unable to make edit with exception [${ex.printStackTrace()}]")).future
         }
@@ -68,9 +68,9 @@ class EditController extends ControllerUtils {
   ): Action[AnyContent] = Action.async { implicit request =>
     Logger.info(s"Editing by period [${period}] for id: ${id}")
     val evalResp = matchByEditParams(Some(id), request, Some(period))
-    val res = evalResp match {
+    val res = (evalResp: @unchecked) match {
       case (x: EditRequestByPeriod) => {
-        val resp = Try(requestEnterprise.updateEnterpriseVariableValues(x.period, x.id, x.updatedBy, x.edits)) match {
+        val resp = Try(requestEnterprise.updateEnterpriseVariableValues(x.period, x.id, x.updatedBy, x.edits.asJava)) match {
           case Success(s) => Ok(errAsJson(OK, "edit_success", s"Edit has been made successfully to Enterprise with id: ${x.id}, for period: ${x.period.toString}")).future
           case Failure(ex) => InternalServerError(errAsJson(INTERNAL_SERVER_ERROR, "edit_error", s"unable to make edit with exception [${ex.printStackTrace()}]")).future
         }

--- a/app/services/DBConnector.scala
+++ b/app/services/DBConnector.scala
@@ -5,7 +5,7 @@ import java.time.format.{ DateTimeFormatter, DateTimeParseException }
 import java.util.Optional
 import javax.naming.ServiceUnavailableException
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ Future, TimeoutException }
 import scala.util.{ Failure, Success, Try }
@@ -44,7 +44,7 @@ trait DBConnector extends Controller with StrictLogging {
   @throws(classOf[DateTimeParseException])
   def validateYearMonth(key: String, raw: String) = {
     val yearAndMonth = Try(YearMonth.parse(raw, DateTimeFormatter.ofPattern("yyyyMM")))
-    yearAndMonth match {
+    (yearAndMonth: @unchecked) match {
       case Success(s) =>
         ReferencePeriod(key, s)
       case Failure(ex: DateTimeParseException) =>
@@ -88,7 +88,7 @@ trait DBConnector extends Controller with StrictLogging {
   def resultMatcher[Z](v: Optional[Z], msg: Option[String] = None): Future[Result] = {
     Future { toOption[Z](v) }.map {
       case Some(x: java.util.List[StatisticalUnit]) =>
-        tryAsResponse(Try(Json.toJson(x.toList.map { v => UnitLinks(v) })))
+        tryAsResponse(Try(Json.toJson(x.asScala.toList.map { v => UnitLinks(v) })))
       case Some(x: Enterprise) =>
         tryAsResponse(Try(Json.toJson(EnterpriseUnit(x))))
       case Some(x: StatisticalUnitLinks) =>
@@ -125,7 +125,7 @@ trait DBConnector extends Controller with StrictLogging {
         BadRequest(errAsJson(BAD_REQUEST, "invalid_key",
           s"invalid id ${i.id}. Check key size[$minKeyLength].")).future
       case _ =>
-        BadRequest(errAsJson(BAD_REQUEST, "missing_param", s"No query specified.")).future
+        BadRequest(errAsJson(BAD_REQUEST, "missing_param", "No query specified.")).future
     }
   }
 

--- a/app/services/HBaseConnect.scala
+++ b/app/services/HBaseConnect.scala
@@ -70,7 +70,7 @@ class HBaseConnect extends DBConnector {
         val resp = Try(requestLinks.getUnitLinks(x.period, x.id, UnitType.fromString(category))).futureTryRes.flatMap {
           case (s: Optional[StatisticalUnitLinks]) => if (s.isPresent) {
             resultMatcher[StatisticalUnitLinks](s)
-          } else NotFound(errAsJson(NOT_FOUND, "not_found", s"Could not find unit link with " +
+          } else NotFound(errAsJson(NOT_FOUND, "not_found", "Could not find unit link with " +
             s"id ${x.id}, period ${x.period} and category $category")).future
         } recover responseException
         resp

--- a/app/services/SQLConnect.scala
+++ b/app/services/SQLConnect.scala
@@ -109,7 +109,7 @@ class SQLConnect extends DBConnector {
         val resp = Try(initSQL.getStatUnitLinksByKey(parseYearMonth(x.period), x.id, category)).futureTryRes.flatMap {
           case Some(v) =>
             tryAsResponse(Try(Json.toJson(KnownUnitLinks(v)))).future
-          case _ => NotFound(errAsJson(NOT_FOUND, "not_found", s"Could not find unit link with " +
+          case _ => NotFound(errAsJson(NOT_FOUND, "not_found", "Could not find unit link with " +
             s"id ${x.id}, period ${x.period} and category $category")).future
         } recover responseException
         resp

--- a/app/uk/gov/ons/sbr/models/units/EnterpriseUnit.scala
+++ b/app/uk/gov/ons/sbr/models/units/EnterpriseUnit.scala
@@ -1,6 +1,6 @@
 package uk.gov.ons.sbr.models.units
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{ JsValue, Json, OFormat }
@@ -27,11 +27,11 @@ object EnterpriseUnit {
   implicit val unitFormat: OFormat[EnterpriseUnit] = Json.format[EnterpriseUnit]
 
   def apply(o: Enterprise): EnterpriseUnit = {
-    val childJson = o.getChildren.map {
+    val childJson = o.getChildren.asScala.map {
       a => Json.parse(a.toUnitHierarchyAsJson)
     }.toList
     // EnterpriseUnit(o.getKey.toLong, o.getReferencePeriod.toString, o.getVariables.toMap, o.getType.toString, childJson)
-    EnterpriseUnit(o.getKey.toLong, o.getReferencePeriod.toString, o.getVariables.toMap, o.getType.toString, childJson)
+    EnterpriseUnit(o.getKey.toLong, o.getReferencePeriod.toString, o.getVariables.asScala.toMap, o.getType.toString, childJson)
   }
 
   def apply(e: StatUnit): EnterpriseUnit = {

--- a/app/uk/gov/ons/sbr/models/units/KnownUnitLinks.scala
+++ b/app/uk/gov/ons/sbr/models/units/KnownUnitLinks.scala
@@ -1,6 +1,6 @@
 package uk.gov.ons.sbr.models.units
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{ Json, OFormat }
@@ -26,12 +26,12 @@ object KnownUnitLinks {
   def apply(u: StatisticalUnitLinks): KnownUnitLinks = {
     val parentMap = u.getParents match {
       case y if !y.isEmpty =>
-        Some(y.map { case (group, id) => group.toString -> id }.toMap)
+        Some(y.asScala.map { case (group, id) => group.toString -> id }.toMap)
       case _ => None
     }
     val childrenMap = u.getChildren match {
       case x if !x.isEmpty =>
-        Some(x.map { case (id, group) => id -> group.toString }.toMap)
+        Some(x.asScala.map { case (id, group) => id -> group.toString }.toMap)
       case _ => None
     }
     KnownUnitLinks(u.getKey, parentMap, childrenMap)

--- a/app/uk/gov/ons/sbr/models/units/UnitLinks.scala
+++ b/app/uk/gov/ons/sbr/models/units/UnitLinks.scala
@@ -1,6 +1,6 @@
 package uk.gov.ons.sbr.models.units
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import io.swagger.annotations.ApiModelProperty
 import play.api.libs.json.{ Json, OFormat }
@@ -28,12 +28,12 @@ object UnitLinks {
   def apply(u: StatisticalUnit): UnitLinks = {
     val parentMap = u.getLinks.getParents match {
       case y if !y.isEmpty =>
-        Some(y.map { case (group, id) => group.toString -> id }.toMap)
+        Some(y.asScala.map { case (group, id) => group.toString -> id }.toMap)
       case _ => None
     }
     val childrenMap = u.getLinks.getChildren match {
       case x if !x.isEmpty =>
-        Some(x.map { case (id, group) => id -> group.toString }.toMap)
+        Some(x.asScala.map { case (id, group) => id -> group.toString }.toMap)
       case _ => None
     }
     UnitLinks(u.getKey, parentMap, childrenMap, u.getType.toString)

--- a/app/utils/Utilities.scala
+++ b/app/utils/Utilities.scala
@@ -20,18 +20,6 @@ object Utilities {
     )
   }
 
-  // ret: AnyVal
-  def getElement(value: Any) = {
-    val res = value match {
-      case None => ""
-      case Some(i: Int) => i
-      case Some(l: Long) => l
-      case Some(z) => s""""${z}""""
-      case x => s"${x.toString}"
-    }
-    res
-  }
-
   def unquote(s: String) = s.replace("\"", "")
 
 }

--- a/test/unit/UtilitiesTestSpec.scala
+++ b/test/unit/UtilitiesTestSpec.scala
@@ -17,15 +17,6 @@ class UtilitiesTestSpec extends TestUtils {
     }
   }
 
-  "getElement" should {
-    "return a Long for Option[Long]" in {
-      val expected = 5784785784L
-      val get = getElement(Some(expected))
-      get must not be a[Option[Long]]
-      get mustEqual expected
-    }
-  }
-
   "unquote" should {
     "removes any unnecessary quotes" in {
       val quoted = """hello this is a\" test"""


### PR DESCRIPTION
Checkstyle warning fixes

- Changed import JavaConversions to JavaConverters and made relevant emendations.
- Added @unchecked to matches to eliminate non-exhaustive warning.
- Removed getElement method as it was causing a warning and not needed.
- Changed interpolated strings to strings where the contents was just a string.