### PR TITLE
Fix/param validation

### DIFF
--- a/app/config/Properties.scala
+++ b/app/config/Properties.scala
@@ -14,9 +14,6 @@ trait Properties {
 
   lazy val dbConfig = propertiesConfig.getConfig("db")
 
-  // Validation
-  lazy val minKeyLength: Int = propertiesConfig.getInt("search.minKeyLength")
-
   // HBase REST
   private val hBaseRestConfig: Config = dbConfig.getConfig("hbase-rest")
   private val hbaseRestNameSpace: String = hBaseRestConfig.getString("namespace")

--- a/app/controllers/v1/SearchController.scala
+++ b/app/controllers/v1/SearchController.scala
@@ -27,19 +27,19 @@ class SearchController @Inject() (db: DataAccess, playConfig: Configuration, lan
   // Use langs implicitly so we don't have to curry messagesApi("message")(langs) with every use of the messagesApi
   implicit val lang: Lang = langs.availables.head
 
-  def validateStatUnitLinksParams(id: String, category: String, period: String, apply: (String, String, String) => Either[StatUnitLinksParams, InvalidParams]): Either[StatUnitLinksParams, InvalidParams] = apply(id, period, category)
+  def validateStatUnitLinksParams(id: String, category: String, period: String, apply: (String, String, String) => Either[InvalidParams, StatUnitLinksParams]): Either[InvalidParams, StatUnitLinksParams] = apply(id, category, period)
 
-  def validateUnitLinksParams(id: String, apply: (String) => Either[UnitLinksParams, InvalidParams]): Either[UnitLinksParams, InvalidParams] = apply(id)
+  def validateUnitLinksParams(id: String, apply: (String) => Either[InvalidParams, UnitLinksParams]): Either[InvalidParams, UnitLinksParams] = apply(id)
 
-  def validateEntParams(id: String, period: Option[String], apply: (String, Option[String]) => Either[EnterpriseParams, InvalidParams]): Either[EnterpriseParams, InvalidParams] = apply(id, period)
+  def validateEntParams(id: String, period: Option[String], apply: (String, Option[String]) => Either[InvalidParams, EnterpriseParams]): Either[InvalidParams, EnterpriseParams] = apply(id, period)
 
-  def handleValidatedParams(params: Either[ValidParams, InvalidParams]): Future[Result] = params match {
-    case Left(v: ValidParams) => v match {
+  def handleValidatedParams(params: Either[InvalidParams, ValidParams]): Future[Result] = params match {
+    case Right(v: ValidParams) => v match {
       case u: UnitLinksParams => dbResultMatcher(db.getUnitLinks(u.id))
       case s: StatUnitLinksParams => dbResultMatcher(db.getStatUnitLinks(s.id, s.category, s.period))
       case e: EnterpriseParams => dbResultMatcher(db.getEnterprise(e.id, e.period))
     }
-    case Right(i: InvalidParams) => BadRequest(messagesApi(i.msg)).future
+    case Left(i: InvalidParams) => BadRequest(messagesApi(i.msg)).future
   }
 
   def dbResultMatcher(result: Future[DbResponse]): Future[Result] = result.map(x => x match {

--- a/app/uk/gov/ons/sbr/models/ValidParams.scala
+++ b/app/uk/gov/ons/sbr/models/ValidParams.scala
@@ -4,15 +4,7 @@ import utils.Validation._
 
 /**
  * Created by coolit on 19/02/2018.
- *
- * I have to call the companion apply methods applyA not apply because they take the same
- * parameters as the normal case class apply method
- * http://www.scala-lang.org/old/node/2211
- *
  */
-
-// @todo - Use dependancy injected config for min/max key length, period format, id regex, valid categories
-// @todo - Make ValidParams trait more dynamic, e.g. common apply method for Ent/UnitLinks
 
 sealed trait ValidParams
 

--- a/app/uk/gov/ons/sbr/models/ValidParams.scala
+++ b/app/uk/gov/ons/sbr/models/ValidParams.scala
@@ -25,10 +25,7 @@ sealed trait ValidParams {
 
   def validId(id: String): Boolean = id.length < maxKeyLength && id.length > minKeyLength
 
-  def validPeriod(period: String): Boolean = Try(YearMonth.parse(period), DateTimeFormat.forPattern(periodFormat)) match {
-    case Success(_) => true
-    case Failure(_) => false
-  }
+  def validPeriod(period: String): Boolean = Try(YearMonth.parse(period, DateTimeFormat.forPattern(periodFormat))).isSuccess
 }
 
 case class UnitLinksParams(id: String) extends ValidParams

--- a/app/uk/gov/ons/sbr/models/ValidParams.scala
+++ b/app/uk/gov/ons/sbr/models/ValidParams.scala
@@ -19,11 +19,11 @@ import scala.util.{ Failure, Success, Try }
 
 sealed trait ValidParams {
 
-  private val minKeyLength: Int = 4
+  private val minKeyLength: Int = 5
   private val maxKeyLength: Int = 20
   private val periodFormat: String = "yyyyMM"
 
-  def validId(id: String): Boolean = id.length < maxKeyLength && id.length > minKeyLength
+  def validId(id: String): Boolean = id.length < (maxKeyLength + 1) && id.length > (minKeyLength - 1)
 
   def validPeriod(period: String): Boolean = Try(YearMonth.parse(period, DateTimeFormat.forPattern(periodFormat))).isSuccess
 }

--- a/app/uk/gov/ons/sbr/models/ValidParams.scala
+++ b/app/uk/gov/ons/sbr/models/ValidParams.scala
@@ -10,27 +10,27 @@ sealed trait ValidParams
 
 case class UnitLinksParams(id: String) extends ValidParams
 object UnitLinksParams extends ValidParams {
-  def validate(id: String): Either[UnitLinksParams, InvalidParams] = id match {
-    case i if (!validId(i)) => Right(InvalidId())
-    case i => Left(UnitLinksParams(i))
+  def validate(id: String): Either[InvalidParams, UnitLinksParams] = id match {
+    case i if (!validId(i)) => Left(InvalidId())
+    case i => Right(UnitLinksParams(i))
   }
 }
 
 case class EnterpriseParams(id: String, period: Option[String]) extends ValidParams
 object EnterpriseParams extends ValidParams {
-  def validate(id: String, period: Option[String]): Either[EnterpriseParams, InvalidParams] = (id, period) match {
-    case (i, _) if (!validId(i)) => Right(InvalidId())
-    case (_, Some(p)) if (!validPeriod(p)) => Right(InvalidPeriod())
-    case (i, p) => Left(EnterpriseParams(i, p))
+  def validate(id: String, period: Option[String]): Either[InvalidParams, EnterpriseParams] = (id, period) match {
+    case (i, _) if (!validId(i)) => Left(InvalidId())
+    case (_, Some(p)) if (!validPeriod(p)) => Left(InvalidPeriod())
+    case (i, p) => Right(EnterpriseParams(i, p))
   }
 }
 
 case class StatUnitLinksParams(id: String, category: String, period: String) extends ValidParams
 object StatUnitLinksParams extends ValidParams {
-  def validate(id: String, period: String, category: String): Either[StatUnitLinksParams, InvalidParams] = (id, period, category) match {
-    case (i, _, _) if (!validId(i)) => Right(InvalidId())
-    case (_, p, _) if (!validPeriod(p)) => Right(InvalidPeriod())
-    case (_, _, c) if (!validCategory(c)) => Right(InvalidCategory())
-    case (i, p, c) => Left(StatUnitLinksParams(i, c, p))
+  def validate(id: String, category: String, period: String): Either[InvalidParams, StatUnitLinksParams] = (id, period, category) match {
+    case (i, _, _) if (!validId(i)) => Left(InvalidId())
+    case (_, p, _) if (!validPeriod(p)) => Left(InvalidPeriod())
+    case (_, _, c) if (!validCategory(c)) => Left(InvalidCategory())
+    case (i, p, c) => Right(StatUnitLinksParams(i, c, p))
   }
 }

--- a/app/uk/gov/ons/sbr/models/ValidParams.scala
+++ b/app/uk/gov/ons/sbr/models/ValidParams.scala
@@ -1,9 +1,6 @@
 package uk.gov.ons.sbr.models
 
-import org.joda.time.YearMonth
-import org.joda.time.format.DateTimeFormat
-
-import scala.util.{ Failure, Success, Try }
+import utils.Validation._
 
 /**
  * Created by coolit on 19/02/2018.
@@ -17,16 +14,7 @@ import scala.util.{ Failure, Success, Try }
 // @todo - Use dependancy injected config for min/max key length, period format, id regex, valid categories
 // @todo - Make ValidParams trait more dynamic, e.g. common apply method for Ent/UnitLinks
 
-sealed trait ValidParams {
-
-  private val minKeyLength: Int = 5
-  private val maxKeyLength: Int = 20
-  private val periodFormat: String = "yyyyMM"
-
-  def validId(id: String): Boolean = id.length < (maxKeyLength + 1) && id.length > (minKeyLength - 1)
-
-  def validPeriod(period: String): Boolean = Try(YearMonth.parse(period, DateTimeFormat.forPattern(periodFormat))).isSuccess
-}
+sealed trait ValidParams
 
 case class UnitLinksParams(id: String) extends ValidParams
 object UnitLinksParams extends ValidParams {
@@ -47,14 +35,10 @@ object EnterpriseParams extends ValidParams {
 
 case class StatUnitLinksParams(id: String, category: String, period: String) extends ValidParams
 object StatUnitLinksParams extends ValidParams {
-  private val validCategories: List[String] = List("ENT", "LEU", "VAT", "PAYE", "CH")
-
   def validate(id: String, period: String, category: String): Either[StatUnitLinksParams, InvalidParams] = (id, period, category) match {
     case (i, _, _) if (!validId(i)) => Right(InvalidId())
     case (_, p, _) if (!validPeriod(p)) => Right(InvalidPeriod())
     case (_, _, c) if (!validCategory(c)) => Right(InvalidCategory())
     case (i, p, c) => Left(StatUnitLinksParams(i, c, p))
   }
-
-  def validCategory(category: String): Boolean = validCategories.contains(category)
 }

--- a/app/utils/Validation.scala
+++ b/app/utils/Validation.scala
@@ -9,12 +9,11 @@ import scala.util.Try
  * Created by coolit on 16/03/2018.
  */
 object Validation {
-  private val minKeyLength: Int = 5
-  private val maxKeyLength: Int = 20
+  private val minKeyLength: Int = 4
   private val periodFormat: String = "yyyyMM"
-  private val validCategories: List[String] = List("ENT", "LEU", "VAT", "PAYE", "CH")
+  private val validCategories: Set[String] = Set("ENT", "LEU", "VAT", "PAYE", "CH")
 
-  def validId(id: String): Boolean = id.length < (maxKeyLength + 1) && id.length > (minKeyLength - 1)
+  def validId(id: String): Boolean = id.length >= minKeyLength
 
   def validPeriod(period: String): Boolean = Try(YearMonth.parse(period, DateTimeFormat.forPattern(periodFormat))).isSuccess
 

--- a/app/utils/Validation.scala
+++ b/app/utils/Validation.scala
@@ -1,0 +1,22 @@
+package utils
+
+import org.joda.time.YearMonth
+import org.joda.time.format.DateTimeFormat
+
+import scala.util.Try
+
+/**
+ * Created by coolit on 16/03/2018.
+ */
+object Validation {
+  private val minKeyLength: Int = 5
+  private val maxKeyLength: Int = 20
+  private val periodFormat: String = "yyyyMM"
+  private val validCategories: List[String] = List("ENT", "LEU", "VAT", "PAYE", "CH")
+
+  def validId(id: String): Boolean = id.length < (maxKeyLength + 1) && id.length > (minKeyLength - 1)
+
+  def validPeriod(period: String): Boolean = Try(YearMonth.parse(period, DateTimeFormat.forPattern(periodFormat))).isSuccess
+
+  def validCategory(category: String): Boolean = validCategories.contains(category)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val api = (project in file("."))
         oldStrategy(x)
     },
     name in Universal := s"${Constant.organisation}-${Constant.appName}",
-    packageName in Universal := s"${Constant.organisation}-${Constant.appName}",
+    packageName in Universal := s"${Constant.organisation}-${Constant.appName}-zip-${version.value}",
     mainClass in assembly := Some("play.core.server.ProdServerStart"),
     fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value),
     dockerBaseImage := "openjdk:8-jre",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -374,22 +374,10 @@ swagger.api.info = {
   licenceUrl = "https://github.com/ONSdigital/sbr-api/blob/master/LICENSE"
 }
 
-validation {
-  search.minKeyLength = 4
-  search.minKeyLenth = ${?SBR_SEARCH_MIN_KEY_LENGTH}
-
-  search.maxKeyLength = 13
-  search.maxKeyLength = ${?SBR_SEARCH_MAX_KEY_LENGTH}
-}
-
 db {
   # Overrride this to use HBase REST
   default = "hbase-in-memory"
   default = ${?SBR_DB_DEFAULT_NAME}
-
-  # We use a year month format
-  period.format = "yyyyMM"
-  period.format = ${?SBR_PERIOD_FORMAT}
 
   # Sample data directory
   # Be careful if you change this value, check HBaseInMemoryConfig.scala for filename standards

--- a/test/server/RouteSpec.scala
+++ b/test/server/RouteSpec.scala
@@ -51,7 +51,7 @@ class RouteSpec extends TestUtils {
     }
 
     "return 400 with invalid date when search with date, id and UnitType" in {
-      val dateSearch = fakeRequest("/v1/periods/20177/types/ENT/units/1244")
+      val dateSearch = fakeRequest("/v1/periods/20177/types/ENT/units/124")
       status(dateSearch) mustBe BAD_REQUEST
     }
   }

--- a/test/unit/ParamsModelTestSpec.scala
+++ b/test/unit/ParamsModelTestSpec.scala
@@ -1,0 +1,73 @@
+package unit
+
+import resource.TestUtils
+import uk.gov.ons.sbr.models._
+
+/**
+ * Created by coolit on 16/03/2018.
+ */
+class ParamsModelTestSpec extends TestUtils {
+
+  private val validId = "12345678"
+  private val invalidId = "1"
+  private val validPeriod = "201802"
+  private val validPeriodOpt = Some(validPeriod)
+  private val invalidPeriod = "3000"
+
+  "UnitLinksParams" should {
+    "return Right(UnitLinkParams) if id param is valid" in {
+      val unitLinks = UnitLinksParams(validId)
+      UnitLinksParams.validate(validId) mustBe Right(unitLinks)
+    }
+
+    "return Left(InvalidId) if id param is invalid" in {
+      UnitLinksParams.validate(invalidId) mustBe Left(InvalidId())
+    }
+  }
+
+  "EnterpriseParams" should {
+    "return Right(EnterpriseParams) if params are valid (no period)" in {
+      val period = None
+      val enterpriseParams = EnterpriseParams(validId, period)
+      EnterpriseParams.validate(validId, period) mustBe Right(enterpriseParams)
+    }
+
+    "return Right(EnterpriseParams) if params are valid (with period)" in {
+      val enterpriseParams = EnterpriseParams(validId, validPeriodOpt)
+      EnterpriseParams.validate(validId, validPeriodOpt) mustBe Right(enterpriseParams)
+    }
+
+    "return Left(InvalidId) if id is invalid" in {
+      EnterpriseParams.validate(invalidId, validPeriodOpt) mustBe Left(InvalidId())
+    }
+
+    "return Left(InvalidId) if period is invalid" in {
+      val period = Some(invalidPeriod)
+      EnterpriseParams.validate(validId, period) mustBe Left(InvalidPeriod())
+    }
+  }
+
+  "StatUnitLinksParams" should {
+    val validCategories: List[String] = List("ENT", "LEU", "VAT", "PAYE", "CH")
+
+    validCategories.foreach(category => {
+      s"return Right(StatUnitLinksParams) for valid params with category [$category]" in {
+        val params = StatUnitLinksParams(validId, category, validPeriod)
+        StatUnitLinksParams.validate(validId, category, validPeriod) mustBe Right(params)
+      }
+    })
+
+    "return Left(InvalidId) if id is invalid" in {
+      StatUnitLinksParams.validate(invalidId, validCategories.head, validPeriod) mustBe Left(InvalidId())
+    }
+
+    "return Left(InvalidPeriod) if period is invalid" in {
+      StatUnitLinksParams.validate(validId, validCategories.head, invalidPeriod) mustBe Left(InvalidPeriod())
+    }
+
+    "return Left(InvalidCategory) if category is invalid" in {
+      val invalidCategory = "enterprise"
+      StatUnitLinksParams.validate(validId, invalidCategory, validPeriod) mustBe Left(InvalidCategory())
+    }
+  }
+}

--- a/test/unit/ValidationTestSpec.scala
+++ b/test/unit/ValidationTestSpec.scala
@@ -25,23 +25,13 @@ class ValidationTestSpec extends TestUtils {
     }
 
     "return true for a valid id (lower end edge case)" in {
-      val edgeCaseLowIdValid = "12345"
+      val edgeCaseLowIdValid = "1234"
       validId(edgeCaseLowIdValid) mustBe true
     }
 
     "return false for an invalid id (lower end edge case)" in {
-      val edgeCaseLowIdInvalid = "1234"
+      val edgeCaseLowIdInvalid = "123"
       validId(edgeCaseLowIdInvalid) mustBe false
-    }
-
-    "return true for a valid id (higher end edge case)" in {
-      val edgeCaseHighIdValid = "12345678911234567892"
-      validId(edgeCaseHighIdValid) mustBe true
-    }
-
-    "return false for an invalid id (higher end edge case)" in {
-      val edgeCaseHighIdInvalid = "123456789112345678923"
-      validId(edgeCaseHighIdInvalid) mustBe false
     }
   }
 

--- a/test/unit/ValidationTestSpec.scala
+++ b/test/unit/ValidationTestSpec.scala
@@ -1,0 +1,89 @@
+package unit
+
+import resource.TestUtils
+import utils.Validation._
+
+/**
+ * Created by coolit on 16/03/2018.
+ */
+class ValidationTestSpec extends TestUtils {
+
+  "validId" should {
+    "return true for a valid id (integer)" in {
+      val correctIdInt = "12345678"
+      validId(correctIdInt) mustBe true
+    }
+
+    "return true for a valid id (chars)" in {
+      val correctIdChars = "123456AB"
+      validId(correctIdChars) mustBe true
+    }
+
+    "return false for an invalid id" in {
+      val invalidId = "0"
+      validId(invalidId) mustBe false
+    }
+
+    "return true for a valid id (lower end edge case)" in {
+      val edgeCaseLowIdValid = "12345"
+      validId(edgeCaseLowIdValid) mustBe true
+    }
+
+    "return false for an invalid id (lower end edge case)" in {
+      val edgeCaseLowIdInvalid = "1234"
+      validId(edgeCaseLowIdInvalid) mustBe false
+    }
+
+    "return true for a valid id (higher end edge case)" in {
+      val edgeCaseHighIdValid = "12345678911234567892"
+      validId(edgeCaseHighIdValid) mustBe true
+    }
+
+    "return false for an invalid id (higher end edge case)" in {
+      val edgeCaseHighIdInvalid = "123456789112345678923"
+      validId(edgeCaseHighIdInvalid) mustBe false
+    }
+  }
+
+  "validPeriod" should {
+    "return true for a valid period" in {
+      val correctPeriod = "201802"
+      validPeriod(correctPeriod) mustBe true
+    }
+
+    "return false for an invalid period (chars)" in {
+      val invalidPeriodChars = "abcdef"
+      validPeriod(invalidPeriodChars) mustBe false
+    }
+
+    "return false for an invalid period (no month)" in {
+      val invalidPeriodYear = "3000"
+      validPeriod(invalidPeriodYear) mustBe false
+    }
+
+    "return false for an invalid period (invalid month - too high)" in {
+      val invalidPeriodTooHigh = "201813"
+      validPeriod(invalidPeriodTooHigh) mustBe false
+    }
+
+    "return false for an invalid period (invalid month - too low)" in {
+      val invalidPeriodTooLow = "201800"
+      validPeriod(invalidPeriodTooLow) mustBe false
+    }
+  }
+
+  "validCategory" should {
+    val validCategories: List[String] = List("ENT", "LEU", "VAT", "PAYE", "CH")
+
+    validCategories.foreach(category => {
+      s"return true for a valid category [$category]" in {
+        validCategory(category) mustBe true
+      }
+    })
+
+    "return false for an invalid category" in {
+      val invalidCategory = "CRN"
+      validCategory(invalidCategory) mustBe false
+    }
+  }
+}


### PR DESCRIPTION
- Move validation methods from `ValidParams` file to `/utils/Validation.scala`
- Fix validation confusion over minimum/maximum key length
- Fix validation issue with no period format being passed to `YearMonth.parse()`
- Change use of `Either` for `ValidParams` and `InvalidParams` so that `Right` is the success case
- Add `ValidationTestSpec` for testing the new `Validation` object
- Add `ParamsModelTestSpec` for testing Valid/Invalid params models
- Remove unused configuration from `application.conf` and `Properties.scala`