### PR TITLE
Refactor row mappers to use declarative field extraction syntax

### DIFF
--- a/app/repository/hbase/legalunit/LegalUnitRowMapper.scala
+++ b/app/repository/hbase/legalunit/LegalUnitRowMapper.scala
@@ -1,14 +1,14 @@
 package repository.hbase.legalunit
 
-import scala.util.Try
-import utils.TrySupport
-
-import uk.gov.ons.sbr.models.enterprise.{ EnterpriseLink, Ern }
-import uk.gov.ons.sbr.models.legalunit.{ LegalUnit, UBRN }
+import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.Logger
+import repository.Field.{ mandatoryStringNamed, optionalIntNamed, optionalStringNamed }
 import repository.RestRepository.Row
 import repository.RowMapper
 import repository.hbase.legalunit.LegalUnitColumns._
 import uk.gov.ons.sbr.models.Address
+import uk.gov.ons.sbr.models.enterprise.{ EnterpriseLink, Ern }
+import uk.gov.ons.sbr.models.legalunit.{ LegalUnit, UBRN }
 
 /*
  * The following fields are optional:
@@ -25,57 +25,40 @@ import uk.gov.ons.sbr.models.Address
  * Note that we use '=' for these fields within the body of the for expression rather than a generator '<-', so
  * that we capture the field as an Option.
  */
-object LegalUnitRowMapper extends RowMapper[LegalUnit] {
+object LegalUnitRowMapper extends RowMapper[LegalUnit] with LazyLogging {
 
-  override def fromRow(variables: Row): Option[LegalUnit] =
+  private implicit val fieldLogger: Logger = logger.underlying
+
+  override def fromRow(variables: Row): Option[LegalUnit] = {
+    val fields = variables.fields
     for {
-      ubrn <- variables.fields.get(ubrn)
-      name <- variables.fields.get(name)
-      sic07 <- variables.fields.get(sic07)
-      legalStatus <- variables.fields.get(legalStatus)
-      tradingStatus <- variables.fields.get(tradingStatus)
-      enterpriseLink <- toEnterpriseLink(variables)
-      address <- toAddress(variables)
-      optTradingStyle = variables.fields.get(tradingstyle)
-      optCrn = variables.fields.get(crn)
+      ubrn <- mandatoryStringNamed(ubrn).apply(fields)
+      name <- mandatoryStringNamed(name).apply(fields)
+      sic07 <- mandatoryStringNamed(sic07).apply(fields)
+      legalStatus <- mandatoryStringNamed(legalStatus).apply(fields)
+      tradingStatus <- mandatoryStringNamed(tradingStatus).apply(fields)
+      enterpriseLink <- toEnterpriseLink(fields)
+      address <- toAddress(fields)
+      optTradingStyle = optionalStringNamed(tradingstyle).apply(fields)
+      optCrn = optionalStringNamed(crn).apply(fields)
+      jobsOpt <- optionalIntNamed(jobs).apply(fields).toOption
+      turnoverOpt <- optionalIntNamed(turnover).apply(fields).toOption
+    } yield LegalUnit(UBRN(ubrn), optCrn, name, legalStatus, tradingStatus, optTradingStyle, sic07, turnoverOpt, jobsOpt, enterpriseLink, address)
+  }
 
-      jobsStr = variables.fields.get(jobs)
-      jobsOptTry = asInt(jobsStr)
-      if invalidInt(jobsOptTry)
-      jobsOptInt = parseTry(jobsOptTry)
-
-      turnoverStr = variables.fields.get(turnover)
-      turnoverOptTry = asInt(turnoverStr)
-      if invalidInt(turnoverOptTry)
-      turnoverOptInt = parseTry(turnoverOptTry)
-
-    } yield LegalUnit(UBRN(ubrn), optCrn, name, legalStatus, tradingStatus, optTradingStyle, sic07, turnoverOptInt, jobsOptInt, enterpriseLink, address)
-
-  private def toEnterpriseLink(variables: Row): Option[EnterpriseLink] =
+  private def toEnterpriseLink(fields: Map[String, String]): Option[EnterpriseLink] =
     for {
-      ern <- variables.fields.get(ern)
-      optEntref = variables.fields.get(entref)
+      ern <- mandatoryStringNamed(ern).apply(fields)
+      optEntref = optionalStringNamed(entref).apply(fields)
     } yield EnterpriseLink(Ern(ern), optEntref)
 
-  private def toAddress(variables: Row): Option[Address] =
+  private def toAddress(fields: Map[String, String]): Option[Address] =
     for {
-      line1 <- variables.fields.get(address1)
-      optLine2 = variables.fields.get(address2)
-      optLine3 = variables.fields.get(address3)
-      optLine4 = variables.fields.get(address4)
-      optLine5 = variables.fields.get(address5)
-      postcode <- variables.fields.get(postcode)
+      line1 <- mandatoryStringNamed(address1).apply(fields)
+      optLine2 = optionalStringNamed(address2).apply(fields)
+      optLine3 = optionalStringNamed(address3).apply(fields)
+      optLine4 = optionalStringNamed(address4).apply(fields)
+      optLine5 = optionalStringNamed(address5).apply(fields)
+      postcode <- mandatoryStringNamed(postcode).apply(fields)
     } yield Address(line1, optLine2, optLine3, optLine4, optLine5, postcode)
-
-  private def parseTry(valueOptTry: Option[Try[Int]]) =
-    valueOptTry.fold[Option[Int]](None) { tryToInt =>
-      // TODO - Add logger for Assertion Exception
-      TrySupport.fold(tryToInt)(failure => throw failure, integralVal => Some(integralVal))
-    }
-
-  private def asInt(fieldAsStr: Option[String]): Option[Try[Int]] =
-    fieldAsStr.map(x => Try(x.toInt))
-
-  private def invalidInt(fieldOptTry: Option[Try[Int]]) =
-    fieldOptTry.fold(true)(_.isSuccess)
 }

--- a/app/repository/hbase/localunit/LocalUnitRowMapper.scala
+++ b/app/repository/hbase/localunit/LocalUnitRowMapper.scala
@@ -1,15 +1,15 @@
 package repository.hbase.localunit
 
-import scala.util.Try
-
-import uk.gov.ons.sbr.models.Address
-import uk.gov.ons.sbr.models.enterprise.{ EnterpriseLink, Ern }
-import uk.gov.ons.sbr.models.localunit.{ LocalUnit, Lurn }
-import uk.gov.ons.sbr.models.reportingunit.{ ReportingUnitLink, Rurn }
-
+import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.Logger
+import repository.Field.{mandatoryIntNamed, mandatoryStringNamed, optionalStringNamed}
 import repository.RestRepository.Row
-import repository.RowMapper
 import repository.hbase.localunit.LocalUnitColumns._
+import repository.{Field, RowMapper}
+import uk.gov.ons.sbr.models.Address
+import uk.gov.ons.sbr.models.enterprise.{EnterpriseLink, Ern}
+import uk.gov.ons.sbr.models.localunit.{LocalUnit, Lurn}
+import uk.gov.ons.sbr.models.reportingunit.{ReportingUnitLink, Rurn}
 
 /*
  * The following fields are optional:
@@ -24,41 +24,44 @@ import repository.hbase.localunit.LocalUnitColumns._
  * Note that we use '=' for these fields within the body of the for expression rather than a generator '<-', so
  * that we capture the field as an Option.
  */
-object LocalUnitRowMapper extends RowMapper[LocalUnit] {
+object LocalUnitRowMapper extends RowMapper[LocalUnit] with LazyLogging {
 
-  override def fromRow(variables: Row): Option[LocalUnit] =
-    for {
-      lurn <- variables.fields.get(lurn)
-      optLuref = variables.fields.get(luref)
-      name <- variables.fields.get(name)
-      optTradingStyle = variables.fields.get(tradingstyle)
-      sic07 <- variables.fields.get(sic07)
-      employees <- variables.fields.get(employees)
-      employeesInt <- Try(employees.toInt).toOption
-      enterpriseLink <- toEnterpriseLink(variables)
-      reportingUnitLink <- toReportingUnitLink(variables)
-      address <- toAddress(variables)
-    } yield LocalUnit(Lurn(lurn), optLuref, enterpriseLink, reportingUnitLink, name, optTradingStyle, address, sic07, employeesInt)
+  private implicit val fieldLogger: Logger = logger.underlying
 
-  private def toReportingUnitLink(variables: Row): Option[ReportingUnitLink] =
+  override def fromRow(variables: Row): Option[LocalUnit] = {
+    val fields = variables.fields
     for {
-      rurn <- variables.fields.get(rurn)
-      optRuref = variables.fields.get(ruref)
-    } yield ReportingUnitLink(Rurn(rurn), optRuref)
+      lurn <- mandatoryStringNamed(lurn).apply(fields)
+      optLuref = optionalStringNamed(luref).apply(fields)
+      name <- mandatoryStringNamed(name).apply(fields)
+      optTradingStyle = optionalStringNamed(tradingstyle).apply(fields)
+      sic07 <- mandatoryStringNamed(sic07).apply(fields)
+      employees <- mandatoryIntNamed(employees).apply(fields).toOption
+      enterpriseLink <- toEnterpriseLink(fields)
+      reportingUnitLink <- toReportingUnitLink(fields)
+      address <- toAddress(fields)
+    } yield LocalUnit(Lurn(lurn), optLuref, enterpriseLink, reportingUnitLink, name, optTradingStyle, address, sic07, employees)
+  }
 
-  private def toEnterpriseLink(variables: Row): Option[EnterpriseLink] =
+  private def toEnterpriseLink(fields: Map[String, String]): Option[EnterpriseLink] =
     for {
-      ern <- variables.fields.get(ern)
-      optEntref = variables.fields.get(entref)
+      ern <- mandatoryStringNamed(ern).apply(fields)
+      optEntref = optionalStringNamed(entref).apply(fields)
     } yield EnterpriseLink(Ern(ern), optEntref)
 
-  private def toAddress(variables: Row): Option[Address] =
+  private def toReportingUnitLink(fields: Map[String, String]): Option[ReportingUnitLink] =
     for {
-      line1 <- variables.fields.get(address1)
-      optLine2 = variables.fields.get(address2)
-      optLine3 = variables.fields.get(address3)
-      optLine4 = variables.fields.get(address4)
-      optLine5 = variables.fields.get(address5)
-      postcode <- variables.fields.get(postcode)
+      rurn <- mandatoryStringNamed(rurn).apply(fields)
+      optRuref = optionalStringNamed(ruref).apply(fields)
+    } yield ReportingUnitLink(Rurn(rurn), optRuref)
+
+  private def toAddress(fields: Map[String, String]): Option[Address] =
+    for {
+      line1 <- mandatoryStringNamed(address1).apply(fields)
+      optLine2 = optionalStringNamed(address2).apply(fields)
+      optLine3 = optionalStringNamed(address3).apply(fields)
+      optLine4 = optionalStringNamed(address4).apply(fields)
+      optLine5 = optionalStringNamed(address5).apply(fields)
+      postcode <- mandatoryStringNamed(postcode).apply(fields)
     } yield Address(line1, optLine2, optLine3, optLine4, optLine5, postcode)
 }

--- a/app/repository/hbase/reportingunit/ReportingUnitRowMapper.scala
+++ b/app/repository/hbase/reportingunit/ReportingUnitRowMapper.scala
@@ -1,39 +1,41 @@
 package repository.hbase.reportingunit
 
+import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.Logger
+import repository.Field.{ mandatoryIntNamed, mandatoryStringNamed, optionalStringNamed }
 import repository.RestRepository.Row
 import repository.RowMapper
 import repository.hbase.reportingunit.ReportingUnitColumns._
 import uk.gov.ons.sbr.models.enterprise.Ern
 import uk.gov.ons.sbr.models.reportingunit.{ ReportingUnit, Rurn }
 
-import scala.util.Try
+object ReportingUnitRowMapper extends RowMapper[ReportingUnit] with LazyLogging {
 
-object ReportingUnitRowMapper extends RowMapper[ReportingUnit] {
+  private implicit val fieldLogger: Logger = logger.underlying
 
-  override def fromRow(variables: Row): Option[ReportingUnit] =
+  override def fromRow(variables: Row): Option[ReportingUnit] = {
+    val fields = variables.fields
     for {
-      rurn <- variables.fields.get(rurn)
-      optRuref = variables.fields.get(ruref)
-      ern <- variables.fields.get(ern)
-      optEntref = variables.fields.get(entref)
-      name <- variables.fields.get(name)
-      optTradingStyle = variables.fields.get(tradingStyle)
-      optLegalStatus = variables.fields.get(legalStatus)
-      address1 <- variables.fields.get(address1)
-      optAddress2 = variables.fields.get(address2)
-      optAddress3 = variables.fields.get(address3)
-      optAddress4 = variables.fields.get(address4)
-      optAddress5 = variables.fields.get(address5)
-      postcode <- variables.fields.get(postcode)
-      sic07 <- variables.fields.get(sic07)
-      employees <- variables.fields.get(employees)
-      employeesInt <- Try(employees.toInt).toOption
-      employment <- variables.fields.get(employment)
-      employmentInt <- Try(employment.toInt).toOption
-      turnover <- variables.fields.get(turnover)
-      turnoverInt <- Try(turnover.toInt).toOption
-      prn <- variables.fields.get(prn)
+      rurn <- mandatoryStringNamed(rurn).apply(fields)
+      optRuref = optionalStringNamed(ruref).apply(fields)
+      ern <- mandatoryStringNamed(ern).apply(fields)
+      optEntref = optionalStringNamed(entref).apply(fields)
+      name <- mandatoryStringNamed(name).apply(fields)
+      optTradingStyle = optionalStringNamed(tradingStyle).apply(fields)
+      optLegalStatus = optionalStringNamed(legalStatus).apply(fields)
+      address1 <- mandatoryStringNamed(address1).apply(fields)
+      optAddress2 = optionalStringNamed(address2).apply(fields)
+      optAddress3 = optionalStringNamed(address3).apply(fields)
+      optAddress4 = optionalStringNamed(address4).apply(fields)
+      optAddress5 = optionalStringNamed(address5).apply(fields)
+      postcode <- mandatoryStringNamed(postcode).apply(fields)
+      sic07 <- mandatoryStringNamed(sic07).apply(fields)
+      employees <- mandatoryIntNamed(employees).apply(fields).toOption
+      employment <- mandatoryIntNamed(employment).apply(fields).toOption
+      turnover <- mandatoryIntNamed(turnover).apply(fields).toOption
+      prn <- mandatoryStringNamed(prn).apply(fields)
     } yield ReportingUnit(Rurn(rurn), optRuref, Ern(ern), optEntref, name, optTradingStyle, optLegalStatus,
-      address1, optAddress2, optAddress3, optAddress4, optAddress5, postcode, sic07, employeesInt, employmentInt,
-      turnoverInt, prn)
+      address1, optAddress2, optAddress3, optAddress4, optAddress5, postcode, sic07, employees, employment,
+      turnover, prn)
+  }
 }

--- a/test/repository/FieldSpec.scala
+++ b/test/repository/FieldSpec.scala
@@ -102,8 +102,8 @@ class FieldSpec extends FreeSpec with Matchers with MockFactory {
     }
 
     "when mandatory" - {
-      "returns Success(Some(value)) when present and a successful conversion" in new Fixture {
-        Typed.mandatory[Int].apply(Employees -> Some(Success(42))) shouldBe Success(Some(42))
+      "returns Success(value) when present and a successful conversion" in new Fixture {
+        Typed.mandatory[Int].apply(Employees -> Some(Success(42))) shouldBe Success(42)
       }
 
       "logs when present and a failed conversion" in new Fixture {
@@ -175,8 +175,8 @@ class FieldSpec extends FreeSpec with Matchers with MockFactory {
     }
 
     "a mandatoryIntNamed" - {
-      "returns Success(Some(int)) when a value is present which represents a valid Int" in new PresentFixture {
-        Field.mandatoryIntNamed(Employees).apply(Variables) shouldBe Success(Some(EmployeesValue.toInt))
+      "returns Success(int) when a value is present which represents a valid Int" in new PresentFixture {
+        Field.mandatoryIntNamed(Employees).apply(Variables) shouldBe Success(EmployeesValue.toInt)
       }
 
       "logs when missing" in new MissingFixture {


### PR DESCRIPTION
Refactor row mappers to use the new functionality defined in Field.
This has the benefit of:
* more declarative row mappers (which are therefore more readable)
* invalid values will be logged in a standardised way