### PR TITLE
Support PAYE references which may be 4 characters in length

### DIFF
--- a/app/repository/hbase/localunit/LocalUnitRowMapper.scala
+++ b/app/repository/hbase/localunit/LocalUnitRowMapper.scala
@@ -2,14 +2,14 @@ package repository.hbase.localunit
 
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.Logger
-import repository.Field.{mandatoryIntNamed, mandatoryStringNamed, optionalStringNamed}
+import repository.Field.{ mandatoryIntNamed, mandatoryStringNamed, optionalStringNamed }
 import repository.RestRepository.Row
 import repository.hbase.localunit.LocalUnitColumns._
-import repository.{Field, RowMapper}
+import repository.{ Field, RowMapper }
 import uk.gov.ons.sbr.models.Address
-import uk.gov.ons.sbr.models.enterprise.{EnterpriseLink, Ern}
-import uk.gov.ons.sbr.models.localunit.{LocalUnit, Lurn}
-import uk.gov.ons.sbr.models.reportingunit.{ReportingUnitLink, Rurn}
+import uk.gov.ons.sbr.models.enterprise.{ EnterpriseLink, Ern }
+import uk.gov.ons.sbr.models.localunit.{ LocalUnit, Lurn }
+import uk.gov.ons.sbr.models.reportingunit.{ ReportingUnitLink, Rurn }
 
 /*
  * The following fields are optional:

--- a/conf/routes
+++ b/conf/routes
@@ -5,7 +5,7 @@
 # Units Feature
 
 GET     /v1/units/:id                                                                                                     controllers.v1.SearchController.retrieveUnitLinks(id)
-GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/$type<(ENT|LEU|LOU|REU|CH|VAT|PAYE)>/units/$unit<.{6,16}>         controllers.v1.UnitLinksController.retrieveUnitLinksWithPeriod(unit, period, type)
+GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/$type<(ENT|LEU|LOU|REU|CH|VAT|PAYE)>/units/$unit<.{4,16}>         controllers.v1.UnitLinksController.retrieveUnitLinksWithPeriod(unit, period, type)
 GET     /v1/periods/:period/types/:type/units/:unit                                                                       controllers.v1.UnitLinksController.badRequest(unit, period, type)
 
 # Enterprises (DEPRECATED)


### PR DESCRIPTION
According to the 'catalogue of variables' page, a PAYE reference may have a minimum length of 4 characters.

This would not be supported at present, as we currently require a minimum length of 6.

This PR relaxes this restriction.