### PR TITLE
Feature/reg 2039 relax id validation

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -1,38 +1,51 @@
 # Routes
 # This file defines all application routes (Higher priority routes first)
+
+# Regex patterns for ID validation temporarily removed until the pipeline allocation of correct ID types is in place
 # ~~~~
 
 # Unit Links
-GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/$type<(ENT|LEU|LOU|REU|CH|VAT|PAYE)>/units/$unit<.{4,16}>       controllers.v1.UnitLinksController.retrieveUnitLinks(unit, period, type)
+#GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/$type<(ENT|LEU|LOU|REU|CH|VAT|PAYE)>/units/$unit<.{4,16}>       controllers.v1.UnitLinksController.retrieveUnitLinks(unit, period, type)
+GET     /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/$type<(ENT|LEU|LOU|REU|CH|VAT|PAYE)>/units/:unit                controllers.v1.UnitLinksController.retrieveUnitLinks(unit, period, type)
 GET     /v1/periods/:period/types/:type/units/:unit                                                                     controllers.BadRequestController.badRequest2(unit, period, type)
 
-PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/VAT/units/$vatref<\d{12}>                                       controllers.v1.UnitLinksController.patchVatUnitLinks(vatref, period)
+#PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/VAT/units/$vatref<\d{12}>                                       controllers.v1.UnitLinksController.patchVatUnitLinks(vatref, period)
+PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/VAT/units/:vatref                                               controllers.v1.UnitLinksController.patchVatUnitLinks(vatref, period)
 PATCH   /v1/periods/:period/types/VAT/units/:vatref                                                                     controllers.BadRequestController.badRequest(vatref, period)
-PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/PAYE/units/$payeref<[0-9a-zA-Z]{4,12}>                          controllers.v1.UnitLinksController.patchPayeUnitLinks(payeref, period)
+#PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/PAYE/units/$payeref<[0-9a-zA-Z]{4,12}>                          controllers.v1.UnitLinksController.patchPayeUnitLinks(payeref, period)
+PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/PAYE/units/:payeref                                             controllers.v1.UnitLinksController.patchPayeUnitLinks(payeref, period)
 PATCH   /v1/periods/:period/types/PAYE/units/:payeref                                                                   controllers.BadRequestController.badRequest(payeref, period)
-PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/LEU/units/$ubrn<\d{16}>                                         controllers.v1.UnitLinksController.patchLeuUnitLinks(ubrn, period)
+#PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/LEU/units/$ubrn<\d{16}>                                         controllers.v1.UnitLinksController.patchLeuUnitLinks(ubrn, period)
+PATCH   /v1/periods/$period<\d{4}(0[1-9]|1[0-2])>/types/LEU/units/:ubrn                                                 controllers.v1.UnitLinksController.patchLeuUnitLinks(ubrn, period)
 PATCH   /v1/periods/:period/types/LEU/units/:ubrn                                                                       controllers.BadRequestController.badRequest(ubrn, period)
 
 # Enterprises
-GET     /v1/periods/$period<\d{4}((0[1-9]|(1[0-2])))>/enterprises/$ern<\d{10}>                                          controllers.v1.EnterpriseUnitController.retrieveEnterpriseUnit(ern, period)
+#GET     /v1/periods/$period<\d{4}((0[1-9]|(1[0-2])))>/enterprises/$ern<\d{10}>                                          controllers.v1.EnterpriseUnitController.retrieveEnterpriseUnit(ern, period)
+GET     /v1/periods/$period<\d{4}((0[1-9]|(1[0-2])))>/enterprises/:ern                                                  controllers.v1.EnterpriseUnitController.retrieveEnterpriseUnit(ern, period)
 GET     /v1/periods/:period/enterprises/:ern                                                                            controllers.BadRequestController.badRequest(ern, period)
 
 # Local Units
-GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/localunits/$lurn<\d{9}>                    controllers.v1.LocalUnitController.retrieveLocalUnit(ern, period, lurn)
+#GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/localunits/$lurn<\d{9}>                    controllers.v1.LocalUnitController.retrieveLocalUnit(ern, period, lurn)
+GET     /v1/enterprises/:ern/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/localunits/:lurn                                   controllers.v1.LocalUnitController.retrieveLocalUnit(ern, period, lurn)
 GET     /v1/enterprises/:ern/periods/:period/localunits/:lurn                                                           controllers.BadRequestController.badRequest3(ern, period, lurn: Option[String])
-GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/localunits                                 controllers.v1.LocalUnitController.retrieveAllLocalUnitsForEnterprise(ern, period)
+#GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/localunits                                 controllers.v1.LocalUnitController.retrieveAllLocalUnitsForEnterprise(ern, period)
+GET     /v1/enterprises/:ern/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/localunits                                         controllers.v1.LocalUnitController.retrieveAllLocalUnitsForEnterprise(ern, period)
 GET     /v1/enterprises/:ern/periods/:period/localunits                                                                 controllers.BadRequestController.badRequest3(ern, period, None: Option[String])
 
 # Legal Units
-GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/legalunits/$ubrn<\d{16}>                   controllers.v1.LegalUnitController.retrieveLegalUnit(ern, period, ubrn)
+#GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/legalunits/$ubrn<\d{16}>                   controllers.v1.LegalUnitController.retrieveLegalUnit(ern, period, ubrn)
+GET     /v1/enterprises/:ern/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/legalunits/:ubrn                                   controllers.v1.LegalUnitController.retrieveLegalUnit(ern, period, ubrn)
 GET     /v1/enterprises/:ern/periods/:period/legalunits/:ubrn                                                           controllers.BadRequestController.badRequest3(ern, period, ubrn: Option[String])
-GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/legalunits                                 controllers.v1.LegalUnitController.retrieveAllLegalUnitsForEnterprise(ern, period)
+#GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/legalunits                                 controllers.v1.LegalUnitController.retrieveAllLegalUnitsForEnterprise(ern, period)
+GET     /v1/enterprises/:ern/periods/$period<\d{4}(0[1-9]|(1[0-2]))>/legalunits                                         controllers.v1.LegalUnitController.retrieveAllLegalUnitsForEnterprise(ern, period)
 GET     /v1/enterprises/:ern/periods/:period/legalunits                                                                 controllers.BadRequestController.badRequest3(ern, period, None: Option[String])
 
 # Reporting Units
-GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|1[0-2])>/reportingunits/$rurn<\d{11}>                 controllers.v1.ReportingUnitController.retrieveReportingUnit(ern, period, rurn)
+#GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|1[0-2])>/reportingunits/$rurn<\d{11}>                 controllers.v1.ReportingUnitController.retrieveReportingUnit(ern, period, rurn)
+GET     /v1/enterprises/:ern/periods/$period<\d{4}(0[1-9]|1[0-2])>/reportingunits/:rurn                                 controllers.v1.ReportingUnitController.retrieveReportingUnit(ern, period, rurn)
 GET     /v1/enterprises/:ern/periods/:period/reportingunits/:rurn                                                       controllers.BadRequestController.badRequest3(ern, period, rurn: Option[String])
-GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|1[0-2])>/reportingunits                               controllers.v1.ReportingUnitController.retrieveAllReportingUnitsForEnterprise(ern, period)
+#GET     /v1/enterprises/$ern<\d{10}>/periods/$period<\d{4}(0[1-9]|1[0-2])>/reportingunits                               controllers.v1.ReportingUnitController.retrieveAllReportingUnitsForEnterprise(ern, period)
+GET     /v1/enterprises/:ern/periods/$period<\d{4}(0[1-9]|1[0-2])>/reportingunits                                       controllers.v1.ReportingUnitController.retrieveAllReportingUnitsForEnterprise(ern, period)
 GET     /v1/enterprises/:ern/periods/:period/reportingunits                                                             controllers.BadRequestController.badRequest3(ern, period, None: Option[String])
 
 # Other Routes

--- a/it/CreateChildLinkFromLegalUnitAcceptanceSpec.scala
+++ b/it/CreateChildLinkFromLegalUnitAcceptanceSpec.scala
@@ -199,10 +199,10 @@ class CreateChildLinkFromLegalUnitAcceptanceSpec extends AbstractServerAcceptanc
       response.status shouldBe NOT_FOUND
     }
 
-    scenario("when the supplied UBRN does not adhere to the expected format") { wsClient =>
+    ignore("when the supplied UBRN does not adhere to the expected format") { wsClient =>
       Given("a valid UBRN is a sixteen digit number")
 
-      When(s"the creation of a child link from UBRN 12345678901234567 to the VAT unit with reference $VatRef is requested")
+      When(s"the creation of a child link from UBRN 12345678901234567 (which has 17 digits) to the VAT unit with reference $VatRef is requested")
       val response = await(wsClient.url(s"/v1/periods/${Period.asString(RegisterPeriod)}/types/$LegalUnitAcronym/units/12345678901234567").
         withHeaders(CONTENT_TYPE -> JsonPatchMediaType).
         patch(s"""[{"op": "add", "path": "/children/$VatRef", "value": "$VatUnitAcronym"}]"""))

--- a/it/EnterpriseAcceptanceSpec.scala
+++ b/it/EnterpriseAcceptanceSpec.scala
@@ -94,7 +94,7 @@ class EnterpriseAcceptanceSpec extends AbstractServerAcceptanceSpec with OptionV
   }
 
   feature("responds to an invalid request") {
-    scenario("rejects request due to Enterprise reference number (ERN) being too short") { wsClient =>
+    ignore("rejects request due to Enterprise reference number (ERN) being too short") { wsClient =>
       Given(s"that an ERN is represented by a ten digit number")
 
       When(s"the user requests an enterprise having an ERN that is not ten digits long")

--- a/it/ReportingUnitAcceptanceSpec.scala
+++ b/it/ReportingUnitAcceptanceSpec.scala
@@ -162,7 +162,7 @@ class ReportingUnitAcceptanceSpec extends AbstractServerAcceptanceSpec with Opti
   }
 
   feature("validate request parameters") {
-    scenario(s"rejecting a Reporting Unit id (RURN) that is not eleven digits long") { wsClient =>
+    ignore(s"rejecting a Reporting Unit id (RURN) that is not eleven digits long") { wsClient =>
       Given(s"that an RURN is represented by an eleven digit number")
 
       When(s"the user requests a Reporting Unit having an RURN that is not eleven digits long")
@@ -172,7 +172,7 @@ class ReportingUnitAcceptanceSpec extends AbstractServerAcceptanceSpec with Opti
       response.status shouldBe BAD_REQUEST
     }
 
-    scenario(s"rejecting an Enterprise reference number (ERN) that is not ten digits long") { wsClient =>
+    ignore(s"rejecting an Enterprise reference number (ERN) that is not ten digits long") { wsClient =>
       Given(s"that an ERN is represented by a ten digit number")
 
       When(s"the user requests a Reporting Unit having an ERN that is not ten digits long")

--- a/it/RetrieveLegalUnitByKeyAcceptanceSpec.scala
+++ b/it/RetrieveLegalUnitByKeyAcceptanceSpec.scala
@@ -87,7 +87,7 @@ class RetrieveLegalUnitByKeyAcceptanceSpec extends AbstractServerAcceptanceSpec 
   }
 
   feature("validate request parameters") {
-    scenario(s"rejecting an Enterprise reference (ERN) that is not ten digits long") { wsClient =>
+    ignore(s"rejecting an Enterprise reference (ERN) that is not ten digits long") { wsClient =>
       Given(s"that an ERN is represented by a ten digit number")
 
       When(s"the user requests a Leqal Unit having an ERN that is not ten digits long")

--- a/it/RetrieveLocalUnitByKeyAcceptanceSpec.scala
+++ b/it/RetrieveLocalUnitByKeyAcceptanceSpec.scala
@@ -90,7 +90,7 @@ class RetrieveLocalUnitByKeyAcceptanceSpec extends AbstractServerAcceptanceSpec 
   }
 
   feature("validate request parameters") {
-    scenario(s"rejecting an Enterprise reference (ERN) that is not ten digits long") { wsClient =>
+    ignore(s"rejecting an Enterprise reference (ERN) that is not ten digits long") { wsClient =>
       Given(s"that an ERN is represented by a ten digit number")
 
       When(s"the user requests a Local Unit having an ERN that is not ten digits long")

--- a/it/UpdateParentLinkFromPayeUnitAcceptanceSpec.scala
+++ b/it/UpdateParentLinkFromPayeUnitAcceptanceSpec.scala
@@ -214,7 +214,7 @@ class UpdateParentLinkFromPayeUnitAcceptanceSpec extends AbstractServerAcceptanc
       response.status shouldBe NOT_FOUND
     }
 
-    scenario("when the supplied PAYE reference does not adhere to the expected format") { wsClient =>
+    ignore("when the supplied PAYE reference does not adhere to the expected format") { wsClient =>
       Given("a valid PAYE reference is an alphanumeric reference between 4 and 12 characters long")
 
       When(s"an update of the parent Legal Unit from $IncorrectUBRN to $TargetUBRN is requested for a PAYE reference containing a non-alphanumeric character")

--- a/it/UpdateParentLinkFromVatUnitAcceptanceSpec.scala
+++ b/it/UpdateParentLinkFromVatUnitAcceptanceSpec.scala
@@ -214,10 +214,10 @@ class UpdateParentLinkFromVatUnitAcceptanceSpec extends AbstractServerAcceptance
       response.status shouldBe NOT_FOUND
     }
 
-    scenario("when the supplied VAT reference does not adhere to the expected format") { wsClient =>
+    ignore("when the supplied VAT reference does not adhere to the expected format") { wsClient =>
       Given("a valid VAT reference is a twelve digit number")
 
-      When(s"an update of the parent Legal Unit from $IncorrectUBRN to $TargetUBRN is requested for the VAT unit with reference 12345678901")
+      When(s"an update of the parent Legal Unit from $IncorrectUBRN to $TargetUBRN is requested for the VAT unit with reference 12345678901 (which has only eleven digits)")
       val response = await(wsClient.url(s"/v1/periods/${Period.asString(RegisterPeriod)}/types/$VatUnitAcronym/units/12345678901").
         withHeaders(CONTENT_TYPE-> JsonPatchMediaType).
         patch(s"""[{"op": "test", "path": "/parents/LEU", "value": "$IncorrectUBRN"},

--- a/test/controllers/v1/EnterpriseUnitRoutingSpec.scala
+++ b/test/controllers/v1/EnterpriseUnitRoutingSpec.scala
@@ -44,21 +44,21 @@ class EnterpriseUnitRoutingSpec extends FreeSpec with GuiceOneAppPerSuite with M
   "A request to retrieve a Enterprise Unit by an Enterprise reference number (ERN) and period (yyyyMM)" - {
     "is rejected when" - {
       "the ERN is" - {
-        "has fewer than 10 digits" in new Fixture {
+        "has fewer than 10 digits" ignore new Fixture {
           val ErnWithFewerDigits = ValidErn.drop(1)
           val Some(result) = fakeRequest(s"/v1/periods/$ValidPeriod/enterprises/$ErnWithFewerDigits")
 
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than 10 digits" in new Fixture {
+        "has more than 10 digits" ignore new Fixture {
           val ErnWithMoreDigits = ValidErn + "11"
           val Some(result) = fakeRequest(s"/v1/periods/$ValidPeriod/enterprises/$ErnWithMoreDigits")
 
           status(result) shouldBe BAD_REQUEST
         }
 
-        "a non-numerical value" in new Fixture {
+        "a non-numerical value" ignore new Fixture {
           val ErnWithNonNumericalValues = new String(Array.fill(ValidErn.length)('A'))
           val Some(result) = fakeRequest(s"/v1/periods/$ValidPeriod/enterprises/$ErnWithNonNumericalValues")
 

--- a/test/controllers/v1/LegalUnitRoutingSpec.scala
+++ b/test/controllers/v1/LegalUnitRoutingSpec.scala
@@ -43,7 +43,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
      */
     "is rejected when" - {
       "the ERN" - {
-        "has fewer than ten digits" in new Fixture {
+        "has fewer than ten digits" ignore new Fixture {
           val ErnTooFewDigits = ValidErn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooFewDigits/periods/$ValidPeriod/legalunits/$ValidUBRN"))
@@ -51,7 +51,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than ten digits" in new Fixture {
+        "has more than ten digits" ignore new Fixture {
           val ErnTooManyDigits = ValidErn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooManyDigits/periods/$ValidPeriod/legalunits/$ValidUBRN"))
@@ -59,7 +59,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val ErnNonNumeric = new String(Array.fill(10)('A'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnNonNumeric/periods/$ValidPeriod/legalunits/$ValidUBRN"))
@@ -69,7 +69,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
       }
 
       "the UBRN" - {
-        "has fewer than sixteen digits" in new Fixture {
+        "has fewer than sixteen digits" ignore new Fixture {
           val UBRNTooFewDigits = ValidUBRN.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/legalunits/$UBRNTooFewDigits"))
@@ -77,7 +77,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than sixteen digits" in new Fixture {
+        "has more than sixteen digits" ignore new Fixture {
           val UBRNTooManyDigits = ValidUBRN + "15"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/legalunits/$UBRNTooManyDigits"))
@@ -85,7 +85,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val UBRNNonNumeric = new String(Array.fill(16)('Z'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/legalunits/$UBRNNonNumeric"))
@@ -173,7 +173,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
      */
     "is rejected when" - {
       "the ERN" - {
-        "has fewer than ten digits" in new Fixture {
+        "has fewer than ten digits" ignore new Fixture {
           val ErnTooFewDigits = ValidErn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooFewDigits/periods/$ValidPeriod/legalunits"))
@@ -181,7 +181,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than ten digits" in new Fixture {
+        "has more than ten digits" ignore new Fixture {
           val ErnTooManyDigits = ValidErn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooManyDigits/periods/$ValidPeriod/legalunits"))
@@ -189,7 +189,7 @@ class LegalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val ErnNonNumeric = new String(Array.fill(10)('A'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnNonNumeric/periods/$ValidPeriod/legalunits"))

--- a/test/controllers/v1/LocalUnitRoutingSpec.scala
+++ b/test/controllers/v1/LocalUnitRoutingSpec.scala
@@ -44,7 +44,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
      */
     "is rejected when" - {
       "the ERN" - {
-        "has fewer than ten digits" in new Fixture {
+        "has fewer than ten digits" ignore new Fixture {
           val ErnTooFewDigits = ValidErn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooFewDigits/periods/$ValidPeriod/localunits/$ValidLurn"))
@@ -52,7 +52,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than ten digits" in new Fixture {
+        "has more than ten digits" ignore new Fixture {
           val ErnTooManyDigits = ValidErn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooManyDigits/periods/$ValidPeriod/localunits/$ValidLurn"))
@@ -60,7 +60,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val ErnNonNumeric = new String(Array.fill(10)('A'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnNonNumeric/periods/$ValidPeriod/localunits/$ValidLurn"))
@@ -70,7 +70,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
       }
 
       "the LURN" - {
-        "has fewer than nine digits" in new Fixture {
+        "has fewer than nine digits" ignore new Fixture {
           val LurnTooFewDigits = ValidLurn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/localunits/$LurnTooFewDigits"))
@@ -78,7 +78,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than nine digits" in new Fixture {
+        "has more than nine digits" ignore new Fixture {
           val LurnTooManyDigits = ValidLurn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/localunits/$LurnTooManyDigits"))
@@ -86,7 +86,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val LurnNonNumeric = new String(Array.fill(9)('Z'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/localunits/$LurnNonNumeric"))
@@ -174,7 +174,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
      */
     "is rejected when" - {
       "the ERN" - {
-        "has fewer than ten digits" in new Fixture {
+        "has fewer than ten digits" ignore new Fixture {
           val ErnTooFewDigits = ValidErn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooFewDigits/periods/$ValidPeriod/localunits"))
@@ -182,7 +182,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than ten digits" in new Fixture {
+        "has more than ten digits" ignore new Fixture {
           val ErnTooManyDigits = ValidErn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooManyDigits/periods/$ValidPeriod/localunits"))
@@ -190,7 +190,7 @@ class LocalUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPerSui
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val ErnNonNumeric = new String(Array.fill(10)('A'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnNonNumeric/periods/$ValidPeriod/localunits"))

--- a/test/controllers/v1/ReportingUnitRoutingSpec.scala
+++ b/test/controllers/v1/ReportingUnitRoutingSpec.scala
@@ -29,7 +29,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
      */
     "is rejected when" - {
       "the ERN" - {
-        "has fewer than ten digits" in new Fixture {
+        "has fewer than ten digits" ignore new Fixture {
           val ErnTooFewDigits = ValidErn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooFewDigits/periods/$ValidPeriod/reportingunits/$ValidRurn"))
@@ -37,7 +37,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than ten digits" in new Fixture {
+        "has more than ten digits" ignore new Fixture {
           val ErnTooManyDigits = ValidErn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooManyDigits/periods/$ValidPeriod/reportingunits/$ValidRurn"))
@@ -45,7 +45,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val ErnNonNumeric = new String(Array.fill(10)('A'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnNonNumeric/periods/$ValidPeriod/reportingunits/$ValidRurn"))
@@ -55,7 +55,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
       }
 
       "the RURN" - {
-        "has fewer than eleven digits" in new Fixture {
+        "has fewer than eleven digits" ignore new Fixture {
           val RurnTooFewDigits = ValidRurn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/reportingunits/$RurnTooFewDigits"))
@@ -63,7 +63,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than eleven digits" in new Fixture {
+        "has more than eleven digits" ignore new Fixture {
           val RurnTooManyDigits = ValidRurn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/reportingunits/$RurnTooManyDigits"))
@@ -71,7 +71,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val RurnNonNumeric = new String(Array.fill(11)('Z'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ValidErn/periods/$ValidPeriod/reportingunits/$RurnNonNumeric"))
@@ -159,7 +159,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
      */
     "is rejected when" - {
       "the ERN" - {
-        "has fewer than ten digits" in new Fixture {
+        "has fewer than ten digits" ignore new Fixture {
           val ErnTooFewDigits = ValidErn.drop(1)
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooFewDigits/periods/$ValidPeriod/reportingunits"))
@@ -167,7 +167,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than ten digits" in new Fixture {
+        "has more than ten digits" ignore new Fixture {
           val ErnTooManyDigits = ValidErn + "9"
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnTooManyDigits/periods/$ValidPeriod/reportingunits"))
@@ -175,7 +175,7 @@ class ReportingUnitRoutingSpec extends FreeSpec with Matchers with GuiceOneAppPe
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new Fixture {
+        "is non-numeric" ignore new Fixture {
           val ErnNonNumeric = new String(Array.fill(10)('A'))
 
           val Some(result) = route(app, FakeRequest(GET, s"/v1/enterprises/$ErnNonNumeric/periods/$ValidPeriod/reportingunits"))

--- a/test/controllers/v1/UnitLinksRoutingSpec.scala
+++ b/test/controllers/v1/UnitLinksRoutingSpec.scala
@@ -184,7 +184,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
 
     "rejected when" - {
       "the UnitId" - {
-        "is too short" in new QueryFixture {
+        "is too short" ignore new QueryFixture {
           val unitIdTooShort = MinLengthUnitId.drop(1)
 
           val Some(result) = routeRequest(url = s"/v1/periods/$ValidPeriod/types/$ValidUnitType/units/$unitIdTooShort")
@@ -192,7 +192,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is too long" in new QueryFixture {
+        "is too long" ignore new QueryFixture {
           val unitIdTooLong = MaxLengthUnitId + "9"
 
           val Some(result) = routeRequest(url = s"/v1/periods/$ValidPeriod/types/$ValidUnitType/units/$unitIdTooLong")
@@ -365,7 +365,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
       }
 
       "the VAT reference" - {
-        "has fewer than twelve digits" in new EditVatFixture {
+        "has fewer than twelve digits" ignore new EditVatFixture {
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/VAT/units/${ValidVatRef.drop(1)}")
 
           val Some(result) = route(app, request)
@@ -373,7 +373,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than twelve digits" in new EditVatFixture {
+        "has more than twelve digits" ignore new EditVatFixture {
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/VAT/units/${ValidVatRef + "9"}")
 
           val Some(result) = route(app, request)
@@ -381,7 +381,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new EditVatFixture {
+        "is non-numeric" ignore new EditVatFixture {
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/VAT/units/${new String(Array.fill(12)('A'))}")
 
           val Some(result) = route(app, request)
@@ -480,7 +480,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
       }
 
       "the PAYE reference" - {
-        "has fewer than four characters" in new EditPayeFixture {
+        "has fewer than four characters" ignore new EditPayeFixture {
           val PayeRefTooFewChars = ValidMinLengthPayeRef.drop(1)
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/PAYE/units/$PayeRefTooFewChars")
 
@@ -489,7 +489,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than twelve characters" in new EditPayeFixture {
+        "has more than twelve characters" ignore new EditPayeFixture {
           val PayeRefTooManyChars = ValidMaxLengthPayeRef + "9"
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/PAYE/units/$PayeRefTooManyChars")
 
@@ -498,7 +498,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "contains a non alphanumeric character" in new EditPayeFixture {
+        "contains a non alphanumeric character" ignore new EditPayeFixture {
           val PayeRefNonAlphanumeric = "-" + ValidMaxLengthPayeRef.drop(1)
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/PAYE/units/$PayeRefNonAlphanumeric")
 
@@ -581,7 +581,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
       }
 
       "the UBRN" - {
-        "has fewer than sixteen digits" in new EditLegalUnitFixture {
+        "has fewer than sixteen digits" ignore new EditLegalUnitFixture {
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/LEU/units/${ValidUbrn.drop(1)}")
 
           val Some(result) = route(app, request)
@@ -589,7 +589,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "has more than sixteen digits" in new EditLegalUnitFixture {
+        "has more than sixteen digits" ignore new EditLegalUnitFixture {
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/LEU/units/${ValidUbrn + "9"}")
 
           val Some(result) = route(app, request)
@@ -597,7 +597,7 @@ class UnitLinksRoutingSpec extends FreeSpec with GuiceOneAppPerTest with Matcher
           status(result) shouldBe BAD_REQUEST
         }
 
-        "is non-numeric" in new EditLegalUnitFixture {
+        "is non-numeric" ignore new EditLegalUnitFixture {
           val request = fakeEditRequest(s"/v1/periods/$ValidPeriod/types/LEU/units/${new String(Array.fill(16)('A'))}")
 
           val Some(result) = route(app, request)


### PR DESCRIPTION
Temporarily remove validation of unit reference formats.
The intention is that this will be re-instated once the pipeline can allocate new references with the expected formats.

Testing in real environments can commence once this has been merged & deployed.

Note that this PR is based on-top of (the as yet un-merged) REG-1604 - as this introduced new routes having reference validation.  See commit ddd819a for only those changes introduced for this story.