### PR TITLE
REG-2333: Use BigDecimal.toPlainString to avoid small PRNs being represented in scientific notation

### DIFF
--- a/app/uk/gov/ons/sbr/models/WritesBigDecimal.scala
+++ b/app/uk/gov/ons/sbr/models/WritesBigDecimal.scala
@@ -4,5 +4,5 @@ import play.api.libs.json.{ JsString, JsValue, Writes }
 
 private[models] object WritesBigDecimal extends Writes[BigDecimal] {
   def writes(bd: BigDecimal): JsValue =
-    JsString(bd.toString())
+    JsString(bd.bigDecimal.toPlainString)
 }

--- a/test/uk/gov/ons/sbr/models/WritesBigDecimalSpec.scala
+++ b/test/uk/gov/ons/sbr/models/WritesBigDecimalSpec.scala
@@ -4,10 +4,21 @@ import org.scalatest.{ FreeSpec, Matchers }
 import play.api.libs.json.JsString
 
 class WritesBigDecimalSpec extends FreeSpec with Matchers {
-
   "A Big Decimal" - {
-    "can be represented as a JSON string in order to retain precision" in {
-      WritesBigDecimal.writes(BigDecimal("2.7182818284")) shouldBe JsString("2.7182818284")
+    "can be represented as a JSON string" - {
+      "in order to retain precision" in {
+        WritesBigDecimal.writes(BigDecimal("2.7182818284")) shouldBe JsString("2.7182818284")
+      }
+
+      /*
+       * This covers very small PRN values.
+       * We do not want such values to be represented in scientific notation - which is the default behaviour of
+       * BigDecimal.toString.
+       * See https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
+       */
+      "in non-scientific notation when very small" in {
+        WritesBigDecimal.writes(BigDecimal("0.000000004")) shouldBe JsString("0.000000004")
+      }
     }
   }
 }

--- a/test/uk/gov/ons/sbr/models/enterprise/EnterpriseSpec.scala
+++ b/test/uk/gov/ons/sbr/models/enterprise/EnterpriseSpec.scala
@@ -51,7 +51,7 @@ class EnterpriseSpec extends FreeSpec with Matchers with OptionValues {
           optionalInt(name = "jobs", optValue = ent.jobs),
           int(name = "workingProprietors", value = ent.workingProprietors),
           int(name = "employment", value = ent.employment),
-          string(name = "prn", value = ent.prn.toString())
+          string(name = "prn", value = ent.prn.bigDecimal.toPlainString)
         )
       }
         ${
@@ -94,6 +94,13 @@ class EnterpriseSpec extends FreeSpec with Matchers with OptionValues {
         )
 
         Json.toJson(sampleEnterpriseWithPartialImputation) shouldBe Json.parse(expectedJsonOutput(sampleEnterpriseWithPartialImputation))
+      }
+
+      // representation should contain the full value in non-scientific format
+      "when the prn is very small" in new Fixture {
+        val sampleEnterpriseWithVerySmallPrn = SampleEnterpriseWithAllFields.copy(prn = BigDecimal("0.000000004"))
+
+        Json.toJson(sampleEnterpriseWithVerySmallPrn) shouldBe Json.parse(expectedJsonOutput(sampleEnterpriseWithVerySmallPrn))
       }
     }
   }

--- a/test/uk/gov/ons/sbr/models/localunit/LocalUnitSpec.scala
+++ b/test/uk/gov/ons/sbr/models/localunit/LocalUnitSpec.scala
@@ -38,7 +38,7 @@ class LocalUnitSpec extends FreeSpec with Matchers {
           int("employees", localUnit.employees),
           int("employment", localUnit.employment),
           string("region", localUnit.region),
-          string("prn", localUnit.prn.toString())
+          string("prn", localUnit.prn.bigDecimal.toPlainString)
         )
       },
          | "address": {${
@@ -61,6 +61,13 @@ class LocalUnitSpec extends FreeSpec with Matchers {
 
       "when only the mandatory fields are defined" in new Fixture {
         Json.toJson(SampleMandatoryValuesLocalUnit) shouldBe Json.parse(expectedJsonStrOf(SampleMandatoryValuesLocalUnit))
+      }
+
+      // representation should contain the full value in non-scientific format
+      "when the prn is very small" in new Fixture {
+        val sampleLocalUnitWithVerySmallPrn = SampleAllValuesLocalUnit.copy(prn = BigDecimal("0.000000001"))
+
+        Json.toJson(sampleLocalUnitWithVerySmallPrn) shouldBe Json.parse(expectedJsonStrOf(sampleLocalUnitWithVerySmallPrn))
       }
     }
   }

--- a/test/uk/gov/ons/sbr/models/reportingunit/ReportingUnitSpec.scala
+++ b/test/uk/gov/ons/sbr/models/reportingunit/ReportingUnitSpec.scala
@@ -42,7 +42,7 @@ class ReportingUnitSpec extends FreeSpec with Matchers {
           int("employment", reportingUnit.employment),
           int("turnover", reportingUnit.turnover),
           string("region", reportingUnit.region),
-          string("prn", reportingUnit.prn.toString())
+          string("prn", reportingUnit.prn.bigDecimal.toPlainString)
         )
       }
       }""".stripMargin
@@ -56,6 +56,13 @@ class ReportingUnitSpec extends FreeSpec with Matchers {
 
       "when only the mandatory fields are defined" in new Fixture {
         Json.toJson(SampleMandatoryValuesReportingUnit) shouldBe Json.parse(expectedJsonStrOf(SampleMandatoryValuesReportingUnit))
+      }
+
+      // representation should contain the full value in non-scientific format
+      "when the prn is very small" in new Fixture {
+        val sampleReportingUnitWithVerySmallPrn = SampleAllValuesReportingUnit.copy(prn = BigDecimal("0.000000003"))
+
+        Json.toJson(sampleReportingUnitWithVerySmallPrn) shouldBe Json.parse(expectedJsonStrOf(sampleReportingUnitWithVerySmallPrn))
       }
     }
   }


### PR DESCRIPTION
Use toPlainString on Java's BigDecimal to get the string representation of a PRN, rather than toString.  This avoids the possibility of scientific notation being used for very small PRNs, e.g. "4E-9" rather than the expected "0.000000004".